### PR TITLE
Delete Meta Info directory

### DIFF
--- a/Meta Info/README.md
+++ b/Meta Info/README.md
@@ -1,1 +1,0 @@
-# This directory contains the rules, foundations and goals using which PAJUPL is designed.


### PR DESCRIPTION
This directory is not needed, go to Documentation instead.